### PR TITLE
Use Navigator.slam_to_goal in SLAM loop

### DIFF
--- a/tests/test_slam_nav_loop.py
+++ b/tests/test_slam_nav_loop.py
@@ -1,0 +1,46 @@
+import importlib
+import sys
+import types
+import unittest.mock as mock
+
+import tests.conftest  # ensure stubs loaded
+
+
+def test_slam_navigation_calls_navigator(monkeypatch):
+    airsim_stub = types.SimpleNamespace(
+        ImageRequest=object,
+        ImageType=object,
+        DrivetrainType=types.SimpleNamespace(ForwardOnly=1),
+        YawMode=lambda *a, **k: None,
+    )
+    monkeypatch.setitem(sys.modules, 'airsim', airsim_stub)
+    nl = importlib.import_module('uav.nav_loop')
+    importlib.reload(nl)
+
+    import slam_bridge.slam_receiver as sr
+    import slam_bridge.frontier_detection as fd
+    monkeypatch.setattr(sr, 'get_latest_pose', lambda: (0.0, 0.0, -2.0))
+    monkeypatch.setattr(sr, 'get_pose_history', lambda: [])
+    monkeypatch.setattr(fd, 'detect_frontiers', lambda m: nl.np.empty((0, 3)))
+    monkeypatch.setattr(nl, 'is_obstacle_ahead', lambda *a, **k: (False, None))
+
+    dummy_future = types.SimpleNamespace(join=lambda *a, **k: None)
+    client = types.SimpleNamespace(
+        simGetCollisionInfo=lambda: types.SimpleNamespace(has_collided=False),
+        moveByVelocityAsync=lambda *a, **k: dummy_future,
+        moveToPositionAsync=lambda *a, **k: dummy_future,
+        hoverAsync=lambda *a, **k: dummy_future,
+        landAsync=lambda *a, **k: dummy_future,
+    )
+
+    navigator = nl.Navigator(client)
+    slam_mock = mock.MagicMock(return_value='slam_nav')
+    monkeypatch.setattr(navigator, 'slam_to_goal', slam_mock)
+
+    ctx = {'navigator': navigator}
+    args = types.SimpleNamespace(max_duration=0, goal_x=1.0, goal_y=2.0, goal_z=-2.0)
+
+    result = nl.slam_navigation_loop(args, client, ctx)
+
+    assert result == 'slam_nav'
+    slam_mock.assert_called_once_with((0.0, 0.0, -2.0), (1.0, 2.0, -2.0))

--- a/uav/nav_loop.py
+++ b/uav/nav_loop.py
@@ -573,6 +573,7 @@ def slam_navigation_loop(args, client, ctx):
     # --- Incorporate exit_flag from ctx for GUI stop button ---
     exit_flag = None
     navigator = None
+    last_action = "none"
     if ctx is not None:
         exit_flag = ctx.get("exit_flag", None)
         navigator = ctx.get("navigator", None)
@@ -657,15 +658,11 @@ def slam_navigation_loop(args, client, ctx):
                         client.landAsync().join()
                         break
 
-                # Move toward goal (simple proportional controller)
-                vx = 1.0 if x < goal_x - threshold else 0.0
-                vy = 1.0 if y < goal_y - threshold else 0.0
-                vz = 0.0  # Maintain altitude
-                if vx != 0.0 or vy != 0.0:
-                    logger.info(f"[SLAMNav] Moving toward goal with vx={vx}, vy={vy}")
-                    client.moveByVelocityAsync(vx, vy, vz, 1, drivetrain=airsim.DrivetrainType.ForwardOnly, yaw_mode=airsim.YawMode(False, 0))
-                else:
-                    logger.info("[SLAMNav] Holding position.")
+                # Move toward goal using Navigator helper
+                if navigator is None:
+                    navigator = Navigator(client)
+                last_action = navigator.slam_to_goal(pose, (goal_x, goal_y, goal_z))
+                logger.info("[SLAMNav] Action: %s", last_action)
 
             # End condition
             if time.time() - start_time > max_duration:
@@ -679,6 +676,7 @@ def slam_navigation_loop(args, client, ctx):
         client.landAsync().join()
     finally:
         logger.info("[SLAMNav] SLAM navigation loop finished.")
+    return last_action
 
 def cleanup(client, sim_process, ctx):
     """Clean up resources and land the drone."""


### PR DESCRIPTION
## Summary
- delegate velocity commands in `slam_navigation_loop` to `Navigator.slam_to_goal`
- return last action from `slam_navigation_loop`
- add regression test verifying the navigator method is called

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870254a746c8325adfbc41d9bed2706