### PR TITLE
Move obstacle and plot utilities

### DIFF
--- a/tests/test_slam_utils.py
+++ b/tests/test_slam_utils.py
@@ -1,0 +1,53 @@
+import importlib
+import sys
+import types
+import unittest.mock as mock
+
+import tests.conftest  # ensure stubs loaded
+
+
+def _load_module(monkeypatch, depth_value=None, height=40):
+    arr = None
+    if depth_value is not None:
+        import numpy as np
+        arr = np.full((height, height), depth_value, dtype=float)
+    airsim_stub = types.SimpleNamespace(
+        ImageRequest=lambda *a, **k: None,
+        ImageType=types.SimpleNamespace(DepthPlanar=0),
+        get_pfm_array=lambda r: arr,
+    )
+    monkeypatch.setitem(sys.modules, "airsim", airsim_stub)
+    su = importlib.import_module("uav.slam_utils")
+    importlib.reload(su)
+    return su
+
+
+def test_is_obstacle_ahead_detects_obstacle(monkeypatch):
+    su = _load_module(monkeypatch, depth_value=1.0)
+    resp = [types.SimpleNamespace(height=40)]
+    client = types.SimpleNamespace(simGetImages=lambda *a, **k: resp)
+    ahead, depth = su.is_obstacle_ahead(client, depth_threshold=2.0)
+    assert ahead is True
+    assert depth == 1.0
+
+
+def test_is_obstacle_ahead_handles_missing_image(monkeypatch):
+    su = _load_module(monkeypatch, depth_value=3.0)
+    client = types.SimpleNamespace(simGetImages=lambda *a, **k: [])
+    ahead, depth = su.is_obstacle_ahead(client)
+    assert ahead is False
+    assert depth is None
+
+
+def test_generate_pose_comparison_plot_invokes_subprocess(monkeypatch):
+    su = _load_module(monkeypatch)
+    run_mock = mock.MagicMock(return_value=types.SimpleNamespace(stdout="ok"))
+    monkeypatch.setattr(su.subprocess, "run", run_mock)
+    su.generate_pose_comparison_plot()
+    run_mock.assert_called_once_with(
+        ["python", "slam_bridge/pose_comparison_plotter.py"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+

--- a/uav/nav_loop.py
+++ b/uav/nav_loop.py
@@ -34,7 +34,11 @@ from uav.context import ParamRefs, NavContext
 from uav.perception_loop import perception_loop, start_perception_thread, process_perception_data
 from uav.navigation_core import detect_obstacle, determine_side_safety, handle_obstacle, navigation_step, apply_navigation_decision
 from uav.navigation_slam_boot import run_slam_bootstrap
-from uav.slam_utils import is_slam_stable
+from uav.slam_utils import (
+    is_slam_stable,
+    is_obstacle_ahead,
+    generate_pose_comparison_plot,
+)
 
 logger = logging.getLogger("nav_loop")
 logger.warning("[TEST] __name__ = %s | handlers = %s", __name__, logger.handlers)
@@ -200,45 +204,6 @@ def navigation_loop(args, client, ctx):
             )
     except KeyboardInterrupt:
         logger.info("Interrupted.")
-
-def is_obstacle_ahead(client, depth_threshold=2.0, vehicle_name="UAV"):
-    from airsim import ImageRequest, ImageType
-    logger.info("[Obstacle Check] Checking for obstacles ahead.")
-    try:
-        responses = client.simGetImages([
-            ImageRequest("oakd_camera", ImageType.DepthPlanar, True)
-        ], vehicle_name=vehicle_name)
-        if not responses or responses[0].height == 0:
-            logger.error("[Obstacle Check] No depth image received or image height is zero.")
-            return False, None
-        depth_image = airsim.get_pfm_array(responses[0])
-        h, w = depth_image.shape
-        cx, cy = w // 2, h // 2
-        roi = depth_image[cy-20:cy+20, cx-20:cx+20]
-        mean_depth = np.nanmean(roi)
-        return mean_depth < depth_threshold, mean_depth
-    except Exception as e:
-        logger.error("[Obstacle Check] Depth read failed: %s", e)
-        return False, None
-
-import subprocess
-
-def generate_pose_comparison_plot():
-    logger.info("[Plotting] Generating pose comparison plot.")
-    try:
-        logger.info("[Plotting] Running pose_comparison_plotter.py script.")
-        result = subprocess.run(
-            ["python", "slam_bridge/pose_comparison_plotter.py"],
-            check=True,
-            capture_output=True,
-            text=True
-        )
-        print("[Plotting] Pose comparison plot generated.")
-        print(result.stdout)
-    except subprocess.CalledProcessError as e:
-        logger.error("[Plotting] Failed to generate pose comparison plot.")
-        print("[Plotting] Failed to generate plot:")
-        print(e.stderr)
 
 def slam_navigation_loop(args, client, ctx):
     """

--- a/uav/slam_utils.py
+++ b/uav/slam_utils.py
@@ -1,8 +1,18 @@
 # uav/slam_utils.py
 import logging
+import subprocess
+from typing import Tuple, Optional
+
+import numpy as np
 # from slam_bridge.slam_receiver import get_latest_pose, get_latest_covariance, get_latest_inliers  # Import functions from slam_receiver.py
 import slam_bridge.slam_receiver as slam_receiver
 
+# Public API
+__all__ = [
+    "is_slam_stable",
+    "is_obstacle_ahead",
+    "generate_pose_comparison_plot",
+]
 # You should define these thresholds as constants.
 SOME_THRESHOLD = 1.0  # Example threshold for pose covariance
 MIN_INLIERS_THRESHOLD = 50  # Example threshold for the minimum number of inliers
@@ -43,3 +53,51 @@ def is_slam_stable():
         return False
     
     return True
+
+
+def is_obstacle_ahead(
+    client, depth_threshold: float = 2.0, vehicle_name: str = "UAV"
+) -> Tuple[bool, Optional[float]]:
+    """Check if a depth obstacle is within ``depth_threshold`` meters."""
+    from airsim import ImageRequest, ImageType
+
+    logger.info("[Obstacle Check] Checking for obstacles ahead.")
+    try:
+        responses = client.simGetImages(
+            [ImageRequest("oakd_camera", ImageType.DepthPlanar, True)],
+            vehicle_name=vehicle_name,
+        )
+        if not responses or responses[0].height == 0:
+            logger.error(
+                "[Obstacle Check] No depth image received or image height is zero."
+            )
+            return False, None
+
+        depth_image = airsim.get_pfm_array(responses[0])
+        h, w = depth_image.shape
+        cx, cy = w // 2, h // 2
+        roi = depth_image[cy - 20 : cy + 20, cx - 20 : cx + 20]
+        mean_depth = np.nanmean(roi)
+        return mean_depth < depth_threshold, float(mean_depth)
+    except Exception as e:  # pragma: no cover - defensive
+        logger.error("[Obstacle Check] Depth read failed: %s", e)
+        return False, None
+
+
+def generate_pose_comparison_plot() -> None:
+    """Invoke the pose comparison plotting helper script."""
+    logger.info("[Plotting] Generating pose comparison plot.")
+    try:
+        logger.info("[Plotting] Running pose_comparison_plotter.py script.")
+        result = subprocess.run(
+            ["python", "slam_bridge/pose_comparison_plotter.py"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        print("[Plotting] Pose comparison plot generated.")
+        print(result.stdout)
+    except subprocess.CalledProcessError as e:  # pragma: no cover - defensive
+        logger.error("[Plotting] Failed to generate pose comparison plot.")
+        print("[Plotting] Failed to generate plot:")
+        print(e.stderr)


### PR DESCRIPTION
## Summary
- move `is_obstacle_ahead` and `generate_pose_comparison_plot` into `slam_utils`
- import utilities from `nav_loop`
- add tests for new util functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b39a19e208325986af11842f282ff