### PR TITLE
Add path configuration for SLAM tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,13 @@ Simulation* writes `nav_mode.flag`. Once all systems report ready, clicking
 Pressing the stop button touches `stop.flag` so the running process can safely
 land and exit.
 
+### SLAM Utilities
+
+Two helper applications live under `linux_slam/app`:
+
+- `offline_slam_evaluation` now accepts `--data-dir=DIR` to specify where RGB and depth images are loaded from.
+- `tcp_slam_server` reads log and flag locations from the command line or the environment variables `SLAM_LOG_DIR`, `SLAM_FLAG_DIR` and `SLAM_IMAGE_DIR`.
+
 
 ---
 

--- a/linux_slam/CMakeLists.txt
+++ b/linux_slam/CMakeLists.txt
@@ -13,8 +13,8 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall   -O3 -march=native")
 
 add_compile_options(-Wno-deprecated-declarations)
 
-# Use C++14 standard
-set(CMAKE_CXX_STANDARD 14)
+# Use C++17 standard
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 message(STATUS "Using C++ standard: ${CMAKE_CXX_STANDARD}")
 


### PR DESCRIPTION
## Summary
- allow offline_slam_evaluation to specify dataset directory
- read TCP SLAM server log and flag locations from arguments or env vars
- create directories with `std::filesystem`
- switch SLAM build to C++17
- document new options in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `bash linux_slam/build.sh` *(fails: OpenCV not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b595024388325baaa261858ca664a